### PR TITLE
Use the Webpack 4 Hooks API

### DIFF
--- a/packages/babel-stylemug-plugin/src/webpack.js
+++ b/packages/babel-stylemug-plugin/src/webpack.js
@@ -7,7 +7,7 @@ module.exports = class StylemPlugin {
   }
 
   apply(compiler) {
-    compiler.plugin('emit', (compilation, cb) => {
+    compiler.hooks.emit.tapAsync('StylemugEmit', (compilation, cb) => {
       const css = extractor.flushAsCss();
       compilation.assets[this.options.name] = new RawSource(css);
       cb();


### PR DESCRIPTION
Switch to the Webpack 4 hooks api (get rid of the annoying deprecation message)