### PR TITLE
(experiment) Added style type errors.

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -6,10 +6,17 @@ const styles = stylemug.create({
   title: {
     fontSize: '31px',
     fontFamily: 'courier',
-    color: '#444',
+    color: 'green',
   },
   titleRed: {
     color: 'red',
+    '&:hover': 'aaa',
+  },
+});
+
+const secondaryStyles = stylemug.create({
+  color: {
+    color: '#444',
   },
 });
 
@@ -22,7 +29,11 @@ export default function App() {
 
   return (
     <div className={styles(globalStyles.container)}>
-      <h1 className={styles('title', show && 'titleRed')}>Hello World</h1>
+      <h1
+        className={styles('title', secondaryStyles.color, show && 'titleRed')}
+      >
+        Hello World
+      </h1>
       <button onClick={onClick}>Click</button>
     </div>
   );

--- a/packages/babel-stylemug-plugin/src/babel.js
+++ b/packages/babel-stylemug-plugin/src/babel.js
@@ -45,7 +45,20 @@ export function babelPlugin(babel) {
             );
             return;
           }
-          sheet = compileSchema(sheet.value);
+
+          try {
+            sheet = compileSchema(sheet.value);
+          } catch (error) {
+            defineError(
+              local,
+              error && error.$$type === 'compilerError'
+                ? error.message
+                : 'The compiler failed with an unknown error.\n' +
+                    'Would you be so kind to report the following error?\n\n' +
+                    error.toString()
+            );
+            return;
+          }
 
           const nextLocal = t.cloneDeep(local.node);
           nextLocal.arguments[0] = t.objectExpression(

--- a/packages/stylemug-compiler/src/compile.js
+++ b/packages/stylemug-compiler/src/compile.js
@@ -9,6 +9,13 @@ function hash(str) {
   return `${prepend}${hash}`;
 }
 
+function throwError(message) {
+  throw {
+    $$type: 'compilerError',
+    message: message,
+  };
+}
+
 export function compileSelectors(selectors, children, media) {
   let result = {};
 
@@ -66,6 +73,14 @@ export function compileSchema(schema) {
   const result = {};
 
   for (let key in schema) {
+    if (typeof schema[key] !== 'object') {
+      throwError(
+        'Invalid schema. Expected className ' +
+          key +
+          ' to be object, but got ' +
+          typeof schema[key]
+      );
+    }
     result[key] = compileSelectors(schema[key], '');
   }
 


### PR DESCRIPTION
Eventually, I'd like to have the compiler provide a list of warnings instead of letting `compileSchema` fail entirely. As well as providing a proper `assert` method to build warning lists.